### PR TITLE
prevent invalid java doc from failing the build in java 8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
    
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <additionalparam>-Xdoclint:none</additionalparam>
     </properties>
 
     <name>nailgun-all</name>


### PR DESCRIPTION
nailgun doesn't build with java 8 due to invalid javadocs.

see http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html for some more details.

Just added a property to prevent doclint from running.