### PR TITLE
Parse UTF-8 arguments

### DIFF
--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSession.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSession.java
@@ -203,7 +203,7 @@ public class NGSession extends Thread {
 
                     byte[] b = new byte[(int) bytesToRead];
                     sockin.readFully(b);
-                    String line = new String(b, "US-ASCII");
+                    String line = new String(b, "UTF-8");
 
                     switch (chunkType) {
 


### PR DESCRIPTION
Simple fix to enable passing UTF-8 on commandline (with properly set up locale of course). Before all multibyte UTF-8 characters were garbled. Due to UTF-8 ASCII back-compat this should produce no ill effects..