### PR TITLE
Remove second definition of buf

### DIFF
--- a/nailgun-client/ng.c
+++ b/nailgun-client/ng.c
@@ -56,8 +56,6 @@
 	#define FILE_SEPARATOR '/'
 	typedef int HANDLE;
 	typedef unsigned int SOCKET;
-	/* buffer used for reading an writing chunk data */
-	char buf[BUFSIZE];
 #endif
 
 #ifndef MIN


### PR DESCRIPTION
This crashes when I try to compile. Note the redefinition of buf on line 117.

 [exec] third-party/nailgun/nailgun-client/ng.c:117:17: error: redefinition of 'char buf [2048]'
 [exec]  char buf[BUFSIZE];
 [exec]                  ^
 [exec] third-party/nailgun/nailgun-client/ng.c:60:7: note: 'char buf [2048]' previously declared here
 [exec]   char buf[BUFSIZE];
 [exec]        ^