### PR TITLE
OSX doesn't seem to have MSG_NOSIGNAL

### DIFF
--- a/nailgun-client/ng.c
+++ b/nailgun-client/ng.c
@@ -59,6 +59,12 @@
 	typedef unsigned int SOCKET;
 #endif
 
+#ifdef __APPLE__
+  #define SEND_FLAGS 0
+#else
+  #define SEND_FLAGS MSG_NOSIGNAL
+#endif
+
 #ifndef MIN
 #define MIN(a,b) ((a<b)?(a):(b))
 #endif
@@ -194,9 +200,9 @@ int sendAll(SOCKET s, char *buf, int len) {
   int total = 0;      
   int bytesleft = len; 
   int n = 0;
-    
+
   while(total < len) {
-    n = send(s, buf+total, bytesleft, MSG_NOSIGNAL);
+    n = send(s, buf+total, bytesleft, SEND_FLAGS);
     
     if (n == -1) { 
       break;


### PR DESCRIPTION
As per the comment on https://github.com/martylamb/nailgun/pull/57 OSX doesn't seem to have MSG_NOSIGNAL. I think this should get it building again, although I don't have an Apple (or Windows) dev environment available. Could setsocketopt SO_NOSIGPIPE as an alternative, if OSX compatibbility is a goal for this project.