### PR TITLE
Compatibility Maven 3.3, reformat pom.xml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,14 @@
 # MinGW32 to cross-compile for windows.  To install and
 # configure MinGW32 on linux, see http://www.mingw.org
 
-
 # This is where the mingw32 compiler exists in Ubuntu 8.04.
 # Your compiler location may vary.
 WIN32_CC=/usr/bin/i586-mingw32msvc-gcc
 
-CC=gcc
+CC?=gcc
 CFLAGS=-Wall -pedantic -s -O3
 SRCDIR=nailgun-client
-PREFIX=/usr/local
+PREFIX?=/usr/local
 
 ng: ${SRCDIR}/ng.c
 	@echo "Building ng client.  To build a Windows binary, type 'make ng.exe'"
@@ -19,12 +18,12 @@ ng: ${SRCDIR}/ng.c
 install: ng
 	install -d ${PREFIX}/bin
 	install ng ${PREFIX}/bin
-	
+
 ng.exe: ${SRCDIR}/ng.c
 	${WIN32_CC} -o ng.exe ${SRCDIR}/ng.c -lwsock32 -O3 ${CFLAGS}
 # any idea why the command line is so sensitive to the order of
 # the arguments?  If CFLAGS is at the beginning, it won't link.
-	
+
 clean:
 	@echo ""
 	@echo "If you have a Windows binary, 'make clean' won't delete it."

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,24 @@
 # Your compiler location may vary.
 WIN32_CC=/usr/bin/i586-mingw32msvc-gcc
 
+OS:=$(shell uname -s)
 CC?=gcc
+STRIP?=strip
 CFLAGS=-Wall -pedantic -s -O3
 SRCDIR=nailgun-client
 PREFIX?=/usr/local
 
+# OSX options, compile 32/64bit binary targetting OS X 10.6 Snow Leopard
+ifeq ($(OS),Darwin)
+CFLAGS=-Wall -pedantic -Os -arch i386 -arch x86_64 -mmacosx-version-min=10.6
+endif
+
 ng: ${SRCDIR}/ng.c
 	@echo "Building ng client.  To build a Windows binary, type 'make ng.exe'"
 	${CC} ${CFLAGS} -o ng ${SRCDIR}/ng.c
+ifeq ($(OS),Darwin)
+	${STRIP} ng
+endif
 
 install: ng
 	install -d ${PREFIX}/bin

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ nailgun
 Nailgun is a client, protocol, and server for running Java programs from
 the command line without incurring the JVM startup overhead.
 
-Programs run in the server (which is implemented in Java), and are 
+Programs run in the server (which is implemented in Java), and are
 triggered by the client (written in C), which handles all I/O.
 
 The server and examples are built using maven.  From the project directory,
 "mvn clean install" will do it.
 
-The client is built using make.  From the project directory, 
+The client is built using make.  From the project directory,
 "make && sudo make install" will do it.  To create the windows client
 you will additionally need to "make ng.exe".
 

--- a/nailgun-examples/pom.xml
+++ b/nailgun-examples/pom.xml
@@ -1,4 +1,3 @@
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -8,26 +7,26 @@
 
     <name>nailgun-examples</name>
     <description>
-        Nailgun is a client, protocol, and server for running Java programs from 
-        the command line without incurring the JVM startup overhead. Programs run 
-        in the server (which is implemented in Java), and are triggered by the 
+        Nailgun is a client, protocol, and server for running Java programs from
+        the command line without incurring the JVM startup overhead. Programs run
+        in the server (which is implemented in Java), and are triggered by the
         client (written in C), which handles all I/O.
-        
+
         This project contains the EXAMPLE CODE ONLY.
     </description>
     <url>http://martiansoftware.com/nailgun</url>
-  
+
     <parent>
         <groupId>com.martiansoftware</groupId>
         <artifactId>nailgun-all</artifactId>
         <version>0.9.2-SNAPSHOT</version>
     </parent>
-  
+
     <dependencies>
         <dependency>
             <groupId>com.martiansoftware</groupId>
             <artifactId>nailgun-server</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/nailgun-server/pom.xml
+++ b/nailgun-server/pom.xml
@@ -1,4 +1,3 @@
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -8,11 +7,11 @@
 
     <name>nailgun-server</name>
     <description>
-        Nailgun is a client, protocol, and server for running Java programs from 
-        the command line without incurring the JVM startup overhead. Programs run 
-        in the server (which is implemented in Java), and are triggered by the 
+        Nailgun is a client, protocol, and server for running Java programs from
+        the command line without incurring the JVM startup overhead. Programs run
+        in the server (which is implemented in Java), and are triggered by the
         client (written in C), which handles all I/O.
-        
+
         This project contains the SERVER ONLY.
     </description>
     <url>http://martiansoftware.com/nailgun</url>
@@ -38,7 +37,7 @@
                     </archive>
                 </configuration>
             </plugin>
-        </plugins>  
-    </build>  
+        </plugins>
+    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,18 +1,17 @@
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.sonatype.oss</groupId>
-		<artifactId>oss-parent</artifactId>
-		<version>7</version>
-	</parent>
-	
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>7</version>
+    </parent>
+
     <groupId>com.martiansoftware</groupId>
     <artifactId>nailgun-all</artifactId>
     <version>0.9.2-SNAPSHOT</version>
     <packaging>pom</packaging>
-   
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <additionalparam>-Xdoclint:none</additionalparam>
@@ -20,11 +19,11 @@
 
     <name>nailgun-all</name>
     <description>
-        Nailgun is a client, protocol, and server for running Java programs 
-        from the command line without incurring the JVM startup overhead. 
-        Programs run in the server (which is implemented in Java), and are 
+        Nailgun is a client, protocol, and server for running Java programs
+        from the command line without incurring the JVM startup overhead.
+        Programs run in the server (which is implemented in Java), and are
         triggered by the client (written in C), which handles all I/O.
-    
+
         This project contains the server and examples.
     </description>
     <url>http://martiansoftware.com/nailgun</url>
@@ -35,14 +34,14 @@
             <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
             <distribution>repo</distribution>
         </license>
-    </licenses>    
+    </licenses>
 
     <scm>
         <url>scm:git:git@github.com:martylamb/nailgun.git</url>
         <connection>scm:git:git@github.com:martylamb/nailgun.git</connection>
         <developerConnection>scm:git:git@github.com:martylamb/nailgun.git</developerConnection>
       <tag>nailgun-all-0.9.1</tag>
-  </scm>
+    </scm>
 
     <developers>
         <developer>
@@ -51,12 +50,12 @@
             <url>http://martiansoftware.com</url>
         </developer>
     </developers>
-	
+
     <modules>
         <module>nailgun-server</module>
         <module>nailgun-examples</module>
     </modules>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -64,8 +63,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.0</version>
                 <configuration>
-                    <source>1.4</source>
-                    <target>1.4</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -80,7 +79,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>        
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -104,7 +103,7 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <distributionManagement>
         <snapshotRepository>
             <id>sonatype-nexus-snapshots</id>
@@ -118,37 +117,37 @@
         </repository>
     </distributionManagement>
 
-	<profiles>
-		<profile>
-			<id>release-sign-artifacts</id>
-			<activation>
-				<property>
-					<name>performRelease</name>
-					<value>true</value>
-				</property>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.4</version>
-						<configuration>
-							<passphrase>${gpg.passphrase}</passphrase>
-						</configuration>
-						<executions>
-							<execution>
-								<id>sign-artifacts</id>
-								<phase>verify</phase>
-								<goals>
-									<goal>sign</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
-   
+    <profiles>
+        <profile>
+            <id>release-sign-artifacts</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.4</version>
+                        <configuration>
+                            <passphrase>${gpg.passphrase}</passphrase>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
- Requires JDK1.6+.
- Optional `$CC` `$PREFIX` from exports envelopment.
- **[WARNING]** The expression ${version} is deprecated. Please use ${project.version} instead.
  
  ``` diff
   <dependencies>
       <dependency>
           <groupId>com.martiansoftware</groupId>
           <artifactId>nailgun-server</artifactId>
  -            <version>${version}</version>
  +            <version>${project.version}</version>
           <scope>compile</scope>
       </dependency>
   </dependencies>
  ```
- **[ERROR]** Source and Target option 1.4 is no longer supported. Use 1.6 or later.
  
  ``` diff
              <groupId>org.apache.maven.plugins</groupId>
              <artifactId>maven-compiler-plugin</artifactId>
              <version>3.0</version>
              <configuration>
  -                    <source>1.4</source>
  +                    <source>1.6</source>
  -                    <target>1.4</target>
  +                    <target>1.6</target>
              </configuration>
  ```
