### PR TITLE
ignore ECONNRESET as well as EPIPE when sending heartbeats

### DIFF
--- a/nailgun-client/ng.c
+++ b/nailgun-client/ng.c
@@ -244,7 +244,7 @@ void sendChunk(unsigned int size, char chunkType, char* buf) {
   bytesSent = sendAll(nailgunsocket, header, CHUNK_HEADER_LEN);
   if (bytesSent != 0 && size > 0) {
     bytesSent = sendAll(nailgunsocket, buf, size);
-  } else if (bytesSent == 0 && (chunkType != CHUNKTYPE_HEARTBEAT || errno != EPIPE)) {
+  } else if (bytesSent == 0 && (chunkType != CHUNKTYPE_HEARTBEAT || !(errno == EPIPE || errno == ECONNRESET))) {
     perror("send");
     handleSocketClose();
   }


### PR DESCRIPTION
I still see very occasional examples of error 227 with buck (see pull #57), and eventually got strace to show an ECONNRESET during heartbeating.