### PR TITLE
Add support for local (Unix domain) sockets using JNA

### DIFF
--- a/nailgun-client/ng.c
+++ b/nailgun-client/ng.c
@@ -29,6 +29,7 @@
 	#include <netdb.h>
 	#include <netinet/in.h>
 	#include <sys/socket.h>
+	#include <sys/un.h>
 	#include <sys/time.h>
 	#include <sys/types.h>
 #endif
@@ -652,7 +653,12 @@ void usage(int exitcode) {
 
 int main(int argc, char *argv[], char *env[]) {
   int i;
-  struct sockaddr_in server_addr;
+  struct sockaddr *server_addr;
+  socklen_t server_addr_len;
+  struct sockaddr_in server_addr_in;
+  #ifndef WIN32
+    struct sockaddr_un server_addr_un;
+  #endif
   char *nailgun_server;        /* server as specified by user */
   char *nailgun_port;          /* port as specified by user */
   char *cwd;
@@ -745,30 +751,60 @@ int main(int argc, char *argv[], char *env[]) {
   if (cmd == NULL) {
     usage(NAILGUN_BAD_ARGUMENTS);
   }
-  
-  /* jump through a series of connection hoops */  
-  hostinfo = gethostbyname(nailgun_server);
 
-  if (hostinfo == NULL) {
-    fprintf(stderr, "Unknown host: %s\n", nailgun_server);
-    cleanUpAndExit(NAILGUN_CONNECT_FAILED);
-  }
- 
-  port = atoi(nailgun_port);
+  #ifndef WIN32
+    if (strncmp(nailgun_server, "local:", 6) == 0) {
+      const char *socket_path = nailgun_server + 6;
+      size_t socket_path_len = strlen(socket_path);
+      if (socket_path_len > sizeof(server_addr_un.sun_path) - 1) {
+        fprintf(stderr, "Socket path [%s] too long (%ld)\n", socket_path, (long) socket_path_len);
+        cleanUpAndExit(NAILGUN_SOCKET_FAILED);
+      }
+      if ((nailgunsocket = socket(PF_LOCAL, SOCK_STREAM, 0)) == -1) {
+        perror("socket");
+        cleanUpAndExit(NAILGUN_SOCKET_FAILED);
+      }
 
-  if ((nailgunsocket = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
-    perror("socket");
-    cleanUpAndExit(NAILGUN_SOCKET_FAILED);
-  }
+      server_addr_un.sun_family = AF_LOCAL;
+      strncpy(server_addr_un.sun_path, socket_path, socket_path_len);
+      server_addr_un.sun_path[socket_path_len] = '\0';
 
-  server_addr.sin_family = AF_INET;    
-  server_addr.sin_port = htons(port);
-  server_addr.sin_addr = *(struct in_addr *) hostinfo->h_addr;
-  
-  memset(&(server_addr.sin_zero), '\0', 8);
+      #ifdef BSD
+        server_addr_un.sun_len = offsetof(struct sockaddr_un, sun_path) + socket_path_len;
+      #endif
+      server_addr = (struct sockaddr *)&server_addr_un;
+      server_addr_len = sizeof(server_addr_un);
+    } else {
+  #endif
 
-  if (connect(nailgunsocket, (struct sockaddr *)&server_addr,
-    sizeof(struct sockaddr)) == -1) {
+      /* jump through a series of connection hoops */
+      hostinfo = gethostbyname(nailgun_server);
+
+      if (hostinfo == NULL) {
+        fprintf(stderr, "Unknown host: %s\n", nailgun_server);
+        cleanUpAndExit(NAILGUN_CONNECT_FAILED);
+      }
+
+      port = atoi(nailgun_port);
+
+      if ((nailgunsocket = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
+        perror("socket");
+        cleanUpAndExit(NAILGUN_SOCKET_FAILED);
+      }
+
+      server_addr_in.sin_family = AF_INET;
+      server_addr_in.sin_port = htons(port);
+      server_addr_in.sin_addr = *(struct in_addr *) hostinfo->h_addr;
+
+      memset(&(server_addr_in.sin_zero), '\0', 8);
+      server_addr = (struct sockaddr *)&server_addr_in;
+      server_addr_len = sizeof(server_addr_in);
+
+  #ifndef WIN32
+    }
+  #endif
+
+  if (connect(nailgunsocket, server_addr, server_addr_len) == -1) {
     perror("connect");
     cleanUpAndExit(NAILGUN_CONNECT_FAILED);
   } 

--- a/nailgun-server/pom.xml
+++ b/nailgun-server/pom.xml
@@ -23,6 +23,14 @@
         <version>0.9.2-SNAPSHOT</version>
     </parent>
 
+    <dependencies>
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna</artifactId>
+        <version>4.1.0</version>
+      </dependency>
+    </dependencies>
+    
     <build>
         <plugins>
             <plugin>

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGListeningAddress.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGListeningAddress.java
@@ -1,0 +1,112 @@
+/*
+
+ Copyright 2004-2015, Martian Software, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ */
+package com.martiansoftware.nailgun;
+
+import java.net.InetAddress;
+
+/**
+ * Represents the address on which the Nailgun server listens.
+ */
+public class NGListeningAddress {
+  private final boolean isInet;
+  private final boolean isLocal;
+  private final InetAddress inetAddress;
+  private final int inetPort;
+  private final String localAddress;
+
+  /**
+   * Constructs a listening address for an internet address and port.
+   */
+  public NGListeningAddress(InetAddress inetAddress, int inetPort) {
+    this.isInet = true;
+    this.isLocal = false;
+    this.inetAddress = inetAddress;
+    this.inetPort = inetPort;
+    this.localAddress = null;
+  }
+
+  /**
+   * Constructs a listening address for a local (Unix domain) address.
+   */
+  public NGListeningAddress(String localAddress) {
+    this.isInet = false;
+    this.isLocal = true;
+    this.inetAddress = null;
+    this.inetPort = -1;
+    this.localAddress = localAddress;
+  }
+
+  /**
+   * Returns true if this listening address has an internet address and port.
+   */
+  public boolean isInetAddress() {
+    return isInet;
+  }
+
+  /**
+   * Returns true if this listening address has a local (Unix domain) address.
+   */
+  public boolean isLocalAddress() {
+    return isLocal;
+  }
+
+  /**
+   * Returns the listening internet address if {@link #isInetAddress()} returns
+   * true. Otherwise, throws.
+   */
+  public InetAddress getInetAddress() {
+    if (!isInet) {
+      throw new IllegalStateException("Family is not INET");
+    }
+    return inetAddress;
+  }
+
+  /**
+   * Returns the listening internet port if {@link #isInetAddress()} returns
+   * true. Otherwise, throws.
+   */
+  public int getInetPort() {
+    if (!isInet) {
+      throw new IllegalStateException("Family is not INET");
+    }
+    return inetPort;
+  }
+
+  /**
+   * Returns the listening local address if {@link #isLocalAddress()} returns
+   * true. Otherwise, throws.
+   */
+  public String getLocalAddress() {
+    if (!isLocal) {
+      throw new IllegalStateException("Family is not LOCAL");
+    }
+    return localAddress;
+  }
+
+  public String toString() {
+    if (isInet) {
+      if (inetAddress != null) {
+        return "address " + inetAddress + " port " + inetPort;
+      } else {
+        return "all addresses, port " + inetPort;
+      }
+    } else {
+      return "local socket " + localAddress;
+    }
+  }
+}

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSession.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSession.java
@@ -237,7 +237,13 @@ public class NGSession extends Thread {
                     }
                 }
 
-                updateThreadName(socket.getInetAddress().getHostAddress() + ": " + command);
+                String threadName;
+                if (socket.getInetAddress() != null) {
+                    threadName = socket.getInetAddress().getHostAddress() + ": " + command;
+                } else {
+                    threadName = command;
+                }
+                updateThreadName(threadName);
 
                 // can't create NGInputStream until we've received a command, because at
                 // that point the stream from the client will only include stdin and stdin-eof

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGUnixDomainServerSocket.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGUnixDomainServerSocket.java
@@ -1,0 +1,145 @@
+/*
+
+ Copyright 2004-2015, Martian Software, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ */
+package com.martiansoftware.nailgun;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketAddress;
+
+import com.sun.jna.LastErrorException;
+import com.sun.jna.ptr.IntByReference;
+
+/**
+ * Implements a {@link ServerSocket} which binds to a local Unix domain socket
+ * and returns instances of {@link NGUnixDomainSocket} from
+ * {@link #accept()}.
+ */
+public class NGUnixDomainServerSocket extends ServerSocket {
+  private static final int DEFAULT_BACKLOG = 50;
+  private final int fd;
+  private final int backlog;
+  private boolean isBound;
+  private boolean isClosed;
+
+  public static class NGUnixDomainServerSocketAddress extends SocketAddress {
+    private final String path;
+
+    public NGUnixDomainServerSocketAddress(String path) {
+      this.path = path;
+    }
+
+    public String getPath() {
+      return path;
+    }
+  }
+
+  /**
+   * Constructs an unbound Unix domain server socket.
+   */
+  public NGUnixDomainServerSocket() throws IOException {
+    this(DEFAULT_BACKLOG, null);
+  }
+
+  /**
+   * Constructs an unbound Unix domain server socket with the specified listen backlog.
+   */
+  public NGUnixDomainServerSocket(int backlog) throws IOException {
+    this(backlog, null);
+  }
+
+  /**
+   * Constructs and binds a Unix domain server socket to the specified path.
+   */
+  public NGUnixDomainServerSocket(String path) throws IOException {
+    this(DEFAULT_BACKLOG, path);
+  }
+
+  /**
+   * Constructs and binds a Unix domain server socket to the specified path
+   * with the specified listen backlog.
+   */
+  public NGUnixDomainServerSocket(int backlog, String path) throws IOException {
+    try {
+      fd = NGUnixDomainSocketLibrary.socket(
+          NGUnixDomainSocketLibrary.PF_LOCAL,
+          NGUnixDomainSocketLibrary.SOCK_STREAM,
+          0);
+      this.backlog = backlog;
+      if (path != null) {
+        bind(new NGUnixDomainServerSocketAddress(path));
+      }
+    } catch (LastErrorException e) {
+      throw new IOException(e);
+    }
+  }
+
+  public synchronized void bind(SocketAddress endpoint) throws IOException {
+    if (!(endpoint instanceof NGUnixDomainServerSocketAddress)) {
+      throw new IllegalArgumentException(
+          "endpoint must be an instance of NGUnixDomainServerSocketAddress");
+    }
+    if (isBound) {
+      throw new IllegalStateException("Socket is already bound");
+    }
+    if (isClosed) {
+      throw new IllegalStateException("Socket is already closed");
+    }
+    NGUnixDomainServerSocketAddress unEndpoint = (NGUnixDomainServerSocketAddress) endpoint;
+    NGUnixDomainSocketLibrary.SockaddrUn address =
+        new NGUnixDomainSocketLibrary.SockaddrUn(unEndpoint.getPath());
+    try {
+      NGUnixDomainSocketLibrary.bind(fd, address, address.size());
+      NGUnixDomainSocketLibrary.listen(fd, backlog);
+      isBound = true;
+    } catch (LastErrorException e) {
+      throw new IOException(e);
+    }
+  }
+
+  public synchronized Socket accept() throws IOException {
+    if (!isBound) {
+      throw new IllegalStateException("Socket is not bound");
+    }
+    if (isClosed) {
+      throw new IllegalStateException("Socket is already closed");
+    }
+    try {
+      NGUnixDomainSocketLibrary.SockaddrUn sockaddrUn =
+          new NGUnixDomainSocketLibrary.SockaddrUn();
+      IntByReference addressLen = new IntByReference();
+      addressLen.setValue(sockaddrUn.size());
+      int clientFd = NGUnixDomainSocketLibrary.accept(fd, sockaddrUn, addressLen);
+      return new NGUnixDomainSocket(clientFd);
+    } catch (LastErrorException e) {
+      throw new IOException(e);
+    }
+  }
+
+  public synchronized void close() throws IOException {
+    if (isClosed) {
+      throw new IllegalStateException("Socket is already closed");
+    }
+    try {
+      NGUnixDomainSocketLibrary.close(fd);
+      isClosed = true;
+    } catch (LastErrorException e) {
+      throw new IOException(e);
+    }
+  }
+}

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGUnixDomainSocket.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGUnixDomainSocket.java
@@ -1,0 +1,142 @@
+/*
+
+ Copyright 2004-2015, Martian Software, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ */
+package com.martiansoftware.nailgun;
+
+import com.sun.jna.LastErrorException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import java.nio.ByteBuffer;
+
+import java.net.Socket;
+
+/**
+ * Implements a {@link Socket} backed by a native Unix domain socket.
+ *
+ * Instances of this class always return {@code null} for
+ * {@link Socket#getInetAddress()}, {@link Socket#getLocalAddress()},
+ * {@link Socket#getLocalSocketAddress()}, {@link Socket#getRemoteSocketAddress()}.
+ */
+public class NGUnixDomainSocket extends Socket {
+  private final int fd;
+  private final InputStream is;
+  private final OutputStream os;
+
+  /**
+   * Creates a Unix domain socket backed by a native file descriptor.
+   */
+  public NGUnixDomainSocket(int fd) {
+    this.fd = fd;
+    this.is = new NGUnixDomainSocketInputStream(fd);
+    this.os = new NGUnixDomainSocketOutputStream(fd);
+  }
+
+  public InputStream getInputStream() {
+    return is;
+  }
+
+  public OutputStream getOutputStream() {
+    return os;
+  }
+
+  public void close() throws IOException {
+    try {
+      NGUnixDomainSocketLibrary.close(fd);
+    } catch (LastErrorException e) {
+      throw new IOException(e);
+    }
+  }
+
+  private static class NGUnixDomainSocketInputStream extends InputStream {
+    private final int fd;
+
+    public NGUnixDomainSocketInputStream(int fd) {
+      this.fd = fd;
+    }
+
+    public int read() throws IOException {
+      ByteBuffer buf = ByteBuffer.allocate(1);
+      int result;
+      if (doRead(buf) == 0) {
+        result = -1;
+      } else {
+        // Make sure to & with 0xFF to avoid sign extension
+        result = 0xFF & buf.get();
+      }
+      return result;
+    }
+
+    public int read(byte[] b, int off, int len) throws IOException {
+      if (len == 0) {
+        return 0;
+      }
+      ByteBuffer buf = ByteBuffer.wrap(b, off, len);
+      int result = doRead(buf);
+      if (result == 0) {
+        result = -1;
+      }
+      return result;
+    }
+
+    private int doRead(ByteBuffer buf) throws IOException {
+      try {
+        int ret = NGUnixDomainSocketLibrary.read(fd, buf, buf.remaining());
+        return ret;
+      } catch (LastErrorException e) {
+        throw new IOException(e);
+      }
+    }
+  }
+
+  private static class NGUnixDomainSocketOutputStream extends OutputStream {
+    private final int fd;
+
+    public NGUnixDomainSocketOutputStream(int fd) {
+      this.fd = fd;
+    }
+
+    public void write(int b) throws IOException {
+      ByteBuffer buf = ByteBuffer.allocate(1);
+      buf.put(0, (byte) (0xFF & b));
+      doWrite(buf);
+    }
+
+    public void write(byte[] b, int off, int len) throws IOException {
+      if (len == 0) {
+        return;
+      }
+      ByteBuffer buf = ByteBuffer.wrap(b, off, len);
+      doWrite(buf);
+    }
+
+    private void doWrite(ByteBuffer buf) throws IOException {
+      try {
+        int ret = NGUnixDomainSocketLibrary.write(fd, buf, buf.remaining());
+        if (ret != buf.remaining()) {
+          // This shouldn't happen with standard blocking Unix domain sockets.
+          throw new IOException("Could not write " + buf.remaining() + " bytes as requested " +
+                                "(wrote " + ret + " bytes instead)");
+        }
+      } catch (LastErrorException e) {
+        throw new IOException(e);
+      }
+    }
+  }
+}

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGUnixDomainSocketLibrary.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGUnixDomainSocketLibrary.java
@@ -1,0 +1,135 @@
+/*
+
+ Copyright 2004-2015, Martian Software, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ */
+package com.martiansoftware.nailgun;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.sun.jna.LastErrorException;
+import com.sun.jna.Native;
+import com.sun.jna.Platform;
+import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.Structure;
+import com.sun.jna.Union;
+
+/**
+ * Utility class to bridge native Unix domain socket calls to Java using JNA.
+ */
+public class NGUnixDomainSocketLibrary {
+  public static final int PF_LOCAL = 1;
+  public static final int AF_LOCAL = 1;
+  public static final int SOCK_STREAM = 1;
+
+  // Utility class, do not instantiate.
+  private NGUnixDomainSocketLibrary() { }
+
+  // BSD platforms write a length byte at the start of struct sockaddr_un.
+  private static final boolean HAS_SUN_LEN =
+      Platform.isMac() || Platform.isFreeBSD() || Platform.isNetBSD() ||
+      Platform.isOpenBSD() || Platform.iskFreeBSD();
+
+  /**
+   * Bridges {@code struct sockaddr_un} to and from native code.
+   */
+  public static class SockaddrUn extends Structure implements Structure.ByReference {
+    /**
+     * On BSD platforms, the {@code sun_len} and {@code sun_family} values in
+     * {@code struct sockaddr_un}.
+     */
+    public static class SunLenAndFamily extends Structure {
+      public byte sunLen;
+      public byte sunFamily;
+
+      protected List getFieldOrder() {
+        return Arrays.asList(new String[] { "sunLen", "sunFamily" });
+      }
+    }
+
+    /**
+     * On BSD platforms, {@code sunLenAndFamily} will be present.
+     * On other platforms, only {@code sunFamily} will be present.
+     */
+    public static class SunFamily extends Union {
+      public SunLenAndFamily sunLenAndFamily;
+      public short sunFamily;
+    }
+
+    public SunFamily sunFamily = new SunFamily();
+    public byte[] sunPath = new byte[104];
+
+    /**
+     * Constructs an empty {@code struct sockaddr_un}.
+     */
+    public SockaddrUn() {
+      if (HAS_SUN_LEN) {
+        sunFamily.sunLenAndFamily = new SunLenAndFamily();
+        sunFamily.setType(SunLenAndFamily.class);
+      } else {
+        sunFamily.setType(Short.TYPE);
+      }
+      allocateMemory();
+    }
+
+    /**
+     * Constructs a {@code struct sockaddr_un} with a path whose bytes are encoded
+     * using the default encoding of the platform.
+     */
+    public SockaddrUn(String path) throws IOException {
+      byte[] pathBytes = path.getBytes();
+      if (pathBytes.length > sunPath.length - 1) {
+        throw new IOException("Cannot fit name [" + path + "] in maximum unix domain socket length");
+      }
+      System.arraycopy(pathBytes, 0, sunPath, 0, pathBytes.length);
+      sunPath[pathBytes.length] = (byte) 0;
+      if (HAS_SUN_LEN) {
+        int len = fieldOffset("sunPath") + pathBytes.length;
+        sunFamily.sunLenAndFamily = new SunLenAndFamily();
+        sunFamily.sunLenAndFamily.sunLen = (byte) len;
+        sunFamily.sunLenAndFamily.sunFamily = AF_LOCAL;
+        sunFamily.setType(SunLenAndFamily.class);
+      } else {
+        sunFamily.sunFamily = AF_LOCAL;
+        sunFamily.setType(Short.TYPE);
+      }
+      allocateMemory();
+    }
+
+    protected List getFieldOrder() {
+      return Arrays.asList(new String[] { "sunFamily", "sunPath" });
+    }
+  }
+
+  static {
+    Native.register(Platform.C_LIBRARY_NAME);
+  }
+
+  public static native int socket(int domain, int type, int protocol) throws LastErrorException;
+  public static native int bind(int fd, SockaddrUn address, int addressLen)
+    throws LastErrorException;
+  public static native int listen(int fd, int backlog) throws LastErrorException;
+  public static native int accept(int fd, SockaddrUn address, IntByReference addressLen)
+    throws LastErrorException;
+  public static native int read(int fd, ByteBuffer buffer, int count)
+    throws LastErrorException;
+  public static native int write(int fd, ByteBuffer buffer, int count)
+    throws LastErrorException;
+  public static native int close(int fd) throws LastErrorException;
+}


### PR DESCRIPTION
The Buck project (which uses Nailgun to persist its daemon) hit a nasty snag when deploying to IPv6-only servers.

On such servers, you have to set a special Java property `java.net.preferIPv6Addresses=true`, or connections fail to hostnames which resolve to both IPv4 and IPv6 addresses.

Unfortunately, setting this to `true` also breaks Nailgun in subtle ways (it binds to the IPv6 `localhost`, which `ng.c` doesn't handle).

A long time ago, I had talked to @jimpurbrick about this, and we agreed it'd be better to use a local (Unix domain) socket instead of TCP/IP to communicate between the Nailgun client and server.

This pull request implements optional local (Unix domain) sockets using JNA to bridge the native calls which are not present in the Java runtime.

If the server is told to use a socket named `local:/path/to/socket`, it creates a Unix domain socket and listens on `/path/to/socket` (which can be a relative path).

This doesn't yet work on Win32, but we can use JNA to implement support for named pipes there in a follow-up.

I tested this on Linux and on Mac OS X.