### PR TITLE
Fix close deadlock

### DIFF
--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGUnixDomainServerSocket.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGUnixDomainServerSocket.java
@@ -112,12 +112,14 @@ public class NGUnixDomainServerSocket extends ServerSocket {
     }
   }
 
-  public synchronized Socket accept() throws IOException {
-    if (!isBound) {
-      throw new IllegalStateException("Socket is not bound");
-    }
-    if (isClosed) {
-      throw new IllegalStateException("Socket is already closed");
+  public Socket accept() throws IOException {
+    synchronized (this) {
+      if (!isBound) {
+        throw new IllegalStateException("Socket is not bound");
+      }
+      if (isClosed) {
+        throw new IllegalStateException("Socket is already closed");
+      }
     }
     try {
       NGUnixDomainSocketLibrary.SockaddrUn sockaddrUn =

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGUnixDomainServerSocket.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGUnixDomainServerSocket.java
@@ -166,9 +166,8 @@ public class NGUnixDomainServerSocket extends ServerSocket {
       throw new IllegalStateException("Socket is already closed");
     }
     try {
-      NGUnixDomainSocketLibrary.close(fd.get());
       // Ensure any pending call to accept() fails.
-      fd.set(-1);
+      NGUnixDomainSocketLibrary.close(fd.getAndSet(-1));
       isClosed = true;
     } catch (LastErrorException e) {
       throw new IOException(e);


### PR DESCRIPTION
I found a dumb deadlock in my implementation of `NGUnixDomainServerSocket`:

```
Thread 1 -> NGUnixDomainServerSocket.accept()
         -> lock this
         -> check isBound and isClosed
         -> NGUnixDomainSocketLibrary.accept(fd)
         -> (blocks indefinitely in accept with lock held)
Thread 2 -> NGUnixDomainServerSocket.close()
         -> try to lock this (which is locked by Thread 1)
         -> deadlock
```

This is because I put `synchronized` on every method which touched the `isBound` or `isClosed` state, so we can't invoke `close()` when we're waiting in `accept()`.

We don't actually need to protect the entire `accept()` method with the lock, just access to the object's state, so this makes the lock more fine-grained to protect just the state.

If we're not careful, this could introduce a possible race condition:

```
Thread 1 -> NGUnixDomainServerSocket.accept()
         -> lock this
         -> check isBound and isClosed
         -> unlock this
         -> descheduled while still in method
Thread 2 -> NGUnixDomainServerSocket.close()
         -> lock this
         -> check isClosed
         -> NGUnixDomainSocketLibrary.close(fd)
         -> now fd is invalid
         -> unlock this
Thread 1 -> re-scheduled while still in method
         -> NGUnixDomainSocketLibrary.accept(fd, which is invalid and maybe re-used)
```

To fix this race condition, I use an `AtomicInteger` to ensure fd is set to an invalid value which can be read without the lock after we call `close()` on it.