### PR TITLE
fix file handle leak with unix domain sockets + fix 227 bug

### DIFF
--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSession.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSession.java
@@ -369,6 +369,7 @@ public class NGSession extends Thread {
                         exit.close();
                     }
                     sockout.flush();
+                    socket.shutdownOutput();
                     socket.close();
                 }
 

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGUnixDomainServerSocket.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGUnixDomainServerSocket.java
@@ -17,14 +17,14 @@
  */
 package com.martiansoftware.nailgun;
 
+import com.sun.jna.LastErrorException;
+import com.sun.jna.ptr.IntByReference;
+
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import com.sun.jna.LastErrorException;
-import com.sun.jna.ptr.IntByReference;
 
 /**
  * Implements a {@link ServerSocket} which binds to a local Unix domain socket
@@ -166,6 +166,7 @@ public class NGUnixDomainServerSocket extends ServerSocket {
       throw new IllegalStateException("Socket is already closed");
     }
     try {
+      super.close();
       // Ensure any pending call to accept() fails.
       NGUnixDomainSocketLibrary.close(fd.getAndSet(-1));
       isClosed = true;

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGUnixDomainSocket.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGUnixDomainSocket.java
@@ -38,6 +38,7 @@ public class NGUnixDomainSocket extends Socket {
   private final int fd;
   private final InputStream is;
   private final OutputStream os;
+  private boolean isConnected = true;
 
   /**
    * Creates a Unix domain socket backed by a native file descriptor.
@@ -46,6 +47,10 @@ public class NGUnixDomainSocket extends Socket {
     this.fd = fd;
     this.is = new NGUnixDomainSocketInputStream(fd);
     this.os = new NGUnixDomainSocketOutputStream(fd);
+  }
+
+  public boolean isConnected() {
+    return isConnected;
   }
 
   public InputStream getInputStream() {
@@ -58,7 +63,9 @@ public class NGUnixDomainSocket extends Socket {
 
   public void close() throws IOException {
     try {
+      super.close();
       NGUnixDomainSocketLibrary.close(fd);
+      isConnected = false;
     } catch (LastErrorException e) {
       throw new IOException(e);
     }


### PR DESCRIPTION
I ran into an issue with #71 because the constructor for Socket() was creating a SocketImpl that reserved a file descriptor and was not being removed by the call to close(). This led to an EMFILE native IO error after the server had been running for a while because the process had run out of file descriptors. I also ran into an issue with the merge of #49 with #71 where socket.shutdownOutput() was failing because Socket.isConnected() was returning false for the client unix domain socket. This diff fixes that issue as well as fixing the 227 error in a slightly better way than #49 did (in which close() was not called).

I have tested this on a nailgun server on Linux that ran over 4000 requests, and it does not leak file handles or experience any disconnects.