### PR TITLE
fix a few bugs with Unix Domain Sockets

### DIFF
--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGInputStream.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGInputStream.java
@@ -149,10 +149,20 @@ public class NGInputStream extends FilterInputStream implements Closeable {
     /**
      * Cancels the thread reading from the NailGun client.
      */
-    public synchronized void close() {
-        readEof();
-		readFuture.cancel(true);
-        executor.shutdownNow();
+    public void close() {
+        synchronized (this) {
+            readEof();
+            readFuture.cancel(true);
+            executor.shutdownNow();
+        }
+        boolean shutdown = false;
+        while (!shutdown) {
+            try {
+                shutdown = executor.awaitTermination(1, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
 	}
 
     /**

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSession.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSession.java
@@ -369,6 +369,7 @@ public class NGSession extends Thread {
                         exit.close();
                     }
                     sockout.flush();
+                    socket.shutdownOutput();
                     socket.close();
                 }
 

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGUnixDomainServerSocket.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGUnixDomainServerSocket.java
@@ -17,14 +17,14 @@
  */
 package com.martiansoftware.nailgun;
 
+import com.sun.jna.LastErrorException;
+import com.sun.jna.ptr.IntByReference;
+
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import com.sun.jna.LastErrorException;
-import com.sun.jna.ptr.IntByReference;
 
 /**
  * Implements a {@link ServerSocket} which binds to a local Unix domain socket
@@ -168,6 +168,7 @@ public class NGUnixDomainServerSocket extends ServerSocket {
     try {
       // Ensure any pending call to accept() fails.
       NGUnixDomainSocketLibrary.close(fd.getAndSet(-1));
+      super.close();
       isClosed = true;
     } catch (LastErrorException e) {
       throw new IOException(e);

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGUnixDomainSocketLibrary.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGUnixDomainSocketLibrary.java
@@ -17,18 +17,17 @@
  */
 package com.martiansoftware.nailgun;
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
-
-import java.util.Arrays;
-import java.util.List;
-
 import com.sun.jna.LastErrorException;
 import com.sun.jna.Native;
 import com.sun.jna.Platform;
-import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.Structure;
 import com.sun.jna.Union;
+import com.sun.jna.ptr.IntByReference;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Utility class to bridge native Unix domain socket calls to Java using JNA.
@@ -132,4 +131,5 @@ public class NGUnixDomainSocketLibrary {
   public static native int write(int fd, ByteBuffer buffer, int count)
     throws LastErrorException;
   public static native int close(int fd) throws LastErrorException;
+  public static native int shutdown(int fd, int how) throws LastErrorException;
 }


### PR DESCRIPTION
This code actually incorporates a couple different bug fixes. First, I have recreated the code to call shutdownOutput, taking into account the unix domain sockets. This change is probably not needed for people who use local sockets only, but it creates a consistent experience that should fix the issue with socket disconnects when using TCP sockets (see https://docs.oracle.com/javase/8/docs/technotes/guides/net/articles/connection_release.html).

Second, I have fixed a minor issue where the Socket() constructor leaks file handles by creating a SocketImpl that is not used for Unix Domain sockets. Calling close on the superclass should fix this issue.

Finally, and perhaps most significantly, I fixed an error that was causing some requests to hang and others to fail in the application layer with random file I/O errors. What was happening is that if the NGInputStream thread does not complete its final read before the socket is closed, it becomes possible for a new requests to open a file descriptor that reuses the same integer handle, causing a race on that file where random bytes out of that file are not read. This caused some threads to hang while trying to read very large numbers of bytes of input, while other threads that read files in the application would read corrupted data.

@bhamiltoncx this last is probably of interest to you because I believe that you will eventually run into the same issue if you use Unix Domain sockets with nailgun.