### PR TITLE
Fix nasty FD re-use race condition in NGUnixDomainSocket

### DIFF
--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSession.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGSession.java
@@ -369,6 +369,8 @@ public class NGSession extends Thread {
                         exit.close();
                     }
                     sockout.flush();
+                    socket.shutdownInput();
+                    socket.shutdownOutput();
                     socket.close();
                 }
 

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGUnixDomainSocketLibrary.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGUnixDomainSocketLibrary.java
@@ -17,18 +17,17 @@
  */
 package com.martiansoftware.nailgun;
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
-
-import java.util.Arrays;
-import java.util.List;
-
 import com.sun.jna.LastErrorException;
 import com.sun.jna.Native;
 import com.sun.jna.Platform;
-import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.Structure;
 import com.sun.jna.Union;
+import com.sun.jna.ptr.IntByReference;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Utility class to bridge native Unix domain socket calls to Java using JNA.
@@ -37,6 +36,9 @@ public class NGUnixDomainSocketLibrary {
   public static final int PF_LOCAL = 1;
   public static final int AF_LOCAL = 1;
   public static final int SOCK_STREAM = 1;
+
+  public static final int SHUT_RD = 0;
+  public static final int SHUT_WR = 1;
 
   // Utility class, do not instantiate.
   private NGUnixDomainSocketLibrary() { }
@@ -132,4 +134,5 @@ public class NGUnixDomainSocketLibrary {
   public static native int write(int fd, ByteBuffer buffer, int count)
     throws LastErrorException;
   public static native int close(int fd) throws LastErrorException;
+  public static native int shutdown(int fd, int how) throws LastErrorException;
 }

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/ReferenceCountedFileDescriptor.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/ReferenceCountedFileDescriptor.java
@@ -1,0 +1,80 @@
+/*
+
+ Copyright 2004-2015, Martian Software, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ */
+package com.martiansoftware.nailgun;
+
+import com.sun.jna.LastErrorException;
+
+import java.io.IOException;
+
+/**
+ * Encapsulates a file descriptor plus a reference count to ensure close requests
+ * only close the file descriptor once the last reference to the file descriptor
+ * is released.
+ *
+ * If not explicitly closed, the file descriptor will be closed when
+ * this object is finalized.
+ */
+public class ReferenceCountedFileDescriptor {
+  private int fd;
+  private int fdRefCount;
+  private boolean closePending;
+
+  public ReferenceCountedFileDescriptor(int fd) {
+    this.fd = fd;
+    this.fdRefCount = 0;
+    this.closePending = false;
+  }
+
+  protected void finalize() throws IOException {
+    close();
+  }
+
+  public synchronized int acquire() {
+    fdRefCount++;
+    return fd;
+  }
+
+  public synchronized void release() throws IOException {
+    fdRefCount--;
+    if (fdRefCount == 0 && closePending && fd != -1) {
+      doClose();
+    }
+  }
+
+  public synchronized void close() throws IOException {
+    if (fd == -1 || closePending) {
+      return;
+    }
+
+    if (fdRefCount == 0) {
+      doClose();
+    } else {
+      // Another thread has the FD. We'll close it when they release the reference.
+      closePending = true;
+    }
+  }
+
+  private void doClose() throws IOException {
+    try {
+      NGUnixDomainSocketLibrary.close(fd);
+      fd = -1;
+    } catch (LastErrorException e) {
+      throw new IOException(e);
+    }
+  }
+}


### PR DESCRIPTION
This is another take on https://github.com/martylamb/nailgun/pull/75 to fix the same underlying race condition in `NGUnixDomainSocket`.

Here's the race:

```
Thread 1:
  NGUnixDomainSocket.NGUnixDomainSocketInputStream.read()
  (gets descheduled before calling NGUnixDomainSocketLibrary.read(fd))
Thread 2:
  NGUnixDomainSocket.close()
  NGUnixDomainSocketLibrary.close(fd)
  (the kernel now marks fd as free to re-use)
Any Thread Except 1:
  fd = open() (or dup(), etc.)
  (due to POSIX rules, kernel will return and re-use the lowest fd—from which Thread 1 is about to read)
Thread 1:
  (gets rescheduled)
  NGUnixDomainSocketLibrary.read(fd)
  (reads garbage from some other unrelated file descriptor, causing havoc)
```

The fix is to do the same thing Java's own `AbstractPlainSocketImpl` does: keep a reference count along with the fd protected by a lock.

Any time we read or write, we first grab the lock, increment the reference count, then unlock, and do the read or write. Once that returns, we grab the lock again, decrement the reference count, and if it's gone to 0 and we have a close pending, we close.

Any time we close, we first grab the lock, check if the reference count is 0, and if so, close and release the lock. Otherwise, we have a read or write pending, so we set a close pending flag and just release the lock.

There is still a very similar race in `NGUnixDomainServerSocket`, but thankfully we only have one thread calling `accept()` and another calling `close()`, so there's no race condition. (If we had multiple threads calling `accept()`, we'd be in trouble.)