### PR TITLE
test-ng.py and fixes for reliable testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /target/
 ng
 *.iml
+*.pyc
 .idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: java
+jdk:
+  - oraclejdk8
+
+script:
+  - scripts/travis_run.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+os: Visual Studio 2015
+
+version: '{build}'
+
+environment:
+  matrix:
+    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+
+install:
+  - cmd: choco install maven -y -f -i
+  - cmd: refreshenv
+  - cmd: set
+  - cmd: python --version
+  - cmd: java -version
+  - cmd: mvn -version
+
+# to disable automatic builds by MsBuild
+build: off
+
+build_script:
+  - "mvn package"
+
+test_script:
+  - "python -m pynailgun.test_ng"

--- a/nailgun-server/pom.xml
+++ b/nailgun-server/pom.xml
@@ -8,11 +8,11 @@
 
     <name>nailgun-server</name>
     <description>
-        Nailgun is a client, protocol, and server for running Java programs from 
-        the command line without incurring the JVM startup overhead. Programs run 
-        in the server (which is implemented in Java), and are triggered by the 
+        Nailgun is a client, protocol, and server for running Java programs from
+        the command line without incurring the JVM startup overhead. Programs run
+        in the server (which is implemented in Java), and are triggered by the
         client (written in C), which handles all I/O.
-        
+
         This project contains the SERVER ONLY.
     </description>
     <url>http://martiansoftware.com/nailgun</url>
@@ -35,7 +35,7 @@
         <version>4.1.0</version>
       </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -51,7 +51,30 @@
                     </archive>
                 </configuration>
             </plugin>
-        </plugins>  
+            <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-shade-plugin</artifactId>
+              <version>3.0.0</version>
+              <executions>
+                <execution>
+                  <phase>package</phase>
+                  <goals>
+                    <goal>shade</goal>
+                  </goals>
+                  <configuration>
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                    <shadedClassifierName>uber</shadedClassifierName>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <transformers>
+                      <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                        <mainClass>com.martiansoftware.nailgun.NGServer</mainClass>
+                      </transformer>
+                    </transformers>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <properties>

--- a/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGWin32NamedPipeLibrary.java
+++ b/nailgun-server/src/main/java/com/martiansoftware/nailgun/NGWin32NamedPipeLibrary.java
@@ -77,7 +77,10 @@ public interface NGWin32NamedPipeLibrary extends WinNT {
             boolean bManualReset,
             boolean bInitialState,
             String lpName);
-    boolean FlushFileBuffers(
-            HANDLE hObject);
+    int WaitForSingleObject(
+            HANDLE hHandle,
+            int dwMilliseconds
+    );
+
     int GetLastError();
 }

--- a/pynailgun/test_ng.py
+++ b/pynailgun/test_ng.py
@@ -1,0 +1,137 @@
+import subprocess
+import os
+import time
+import StringIO
+import unittest
+import tempfile
+import shutil
+import uuid
+
+import pkg_resources
+
+from pynailgun import NailgunException, NailgunConnection
+
+
+POSSIBLE_NAILGUN_CODES_ON_NG_STOP = [
+    NailgunException.CONNECT_FAILED,
+    NailgunException.CONNECTION_BROKEN,
+    NailgunException.UNEXPECTED_CHUNKTYPE,
+]
+
+
+if os.name == 'posix':
+    def transport_exists(transport_file):
+        return os.path.exists(transport_file)
+
+
+if os.name == 'nt':
+    import ctypes
+    from ctypes.wintypes import WIN32_FIND_DATAW as WIN32_FIND_DATA
+    INVALID_HANDLE_VALUE = -1
+    FindFirstFile = ctypes.windll.kernel32.FindFirstFileW
+    FindClose = ctypes.windll.kernel32.FindClose
+
+    # on windows os.path.exists doen't allow to check reliably that a pipe exists
+    # (os.path.exists tries to open connection to a pipe)
+    def transport_exists(transport_path):
+        wfd = WIN32_FIND_DATA()
+        handle = FindFirstFile(transport_path, ctypes.byref(wfd))
+        result = handle != INVALID_HANDLE_VALUE
+        FindClose(handle)
+        return result
+
+
+@unittest.skip('This test is flaky')
+class TestNailgunConnection(unittest.TestCase):
+    def setUp(self):
+        self.setUpTransport()
+        self.startNailgun()
+
+    def setUpTransport(self):
+        self.tmpdir = tempfile.mkdtemp()
+        if os.name == 'posix':
+            self.transport_file = os.path.join(self.tmpdir, 'sock')
+            self.transport_address = 'local:{0}'.format(self.transport_file)
+        else:
+            pipe_name = u'nailgun-test-{0}'.format(uuid.uuid4().hex)
+            self.transport_address = u'local:{0}'.format(pipe_name)
+            self.transport_file = ur'\\.\pipe\{0}'.format(pipe_name)
+
+    def getNailgunUberJar(self):
+        stream = pkg_resources.resource_stream(__name__, 'nailgun-uber.jar')
+        uber_jar_path = os.path.join(self.tmpdir, 'nailgun-uber.jar')
+        with open(uber_jar_path, 'wb') as f:
+            f.write(stream.read())
+        return uber_jar_path
+
+    def startNailgun(self):
+        if os.name == 'posix':
+            def preexec_fn():
+                # Close any open file descriptors to further separate buckd from its
+                # invoking context (e.g. otherwise we'd hang when running things like
+                # `ssh localhost buck clean`).
+                dev_null_fd = os.open("/dev/null", os.O_RDWR)
+                os.dup2(dev_null_fd, 0)
+                os.dup2(dev_null_fd, 1)
+                os.dup2(dev_null_fd, 2)
+                os.close(dev_null_fd)
+            creationflags = 0
+        else:
+            preexec_fn = None
+            # https://msdn.microsoft.com/en-us/library/windows/desktop/ms684863.aspx#DETACHED_PROCESS
+            DETACHED_PROCESS = 0x00000008
+            creationflags = DETACHED_PROCESS
+
+        self.ng_server_process = subprocess.Popen(
+            ['java', '-Djna.nosys=true', '-jar', self.getNailgunUberJar(), self.transport_address],
+            close_fds=True,
+            preexec_fn=preexec_fn,
+            creationflags=creationflags,
+        )
+
+        self.assertIsNone(self.ng_server_process.poll())
+
+        # Give Java some time to create the listening socket.
+        for i in range(0, 600):
+            if not transport_exists(self.transport_file):
+                time.sleep(0.01)
+
+        self.assertTrue(transport_exists(self.transport_file))
+
+    def test_nailgun_stats_and_stop(self):
+        for i in range(1, 5):
+            output = StringIO.StringIO()
+            with NailgunConnection(
+                    self.transport_address,
+                    stderr=None,
+                    stdin=None,
+                    stdout=output) as c:
+                exit_code = c.send_command('ng-stats')
+                self.assertEqual(exit_code, 0)
+            actual_out = output.getvalue().strip()
+            expected_out = 'com.martiansoftware.nailgun.builtins.NGServerStats: {0}/1'.format(i)
+            self.assertEqual(actual_out, expected_out)
+
+        try:
+            with NailgunConnection(
+                    self.transport_address,
+                    cwd=os.getcwd(),
+                    stderr=None,
+                    stdin=None,
+                    stdout=None) as c:
+                c.send_command('ng-stop')
+        except NailgunException as e:
+            self.assertIn(e.code, POSSIBLE_NAILGUN_CODES_ON_NG_STOP)
+
+        self.ng_server_process.wait()
+        self.assertEqual(self.ng_server_process.poll(), 0)
+
+    def tearDown(self):
+        if self.ng_server_process.poll() is None:
+            # some test has failed, ng-server was not stopped. killing it
+            self.ng_server_process.kill()
+        shutil.rmtree(self.tmpdir)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pynailgun/test_ng.py
+++ b/pynailgun/test_ng.py
@@ -6,8 +6,7 @@ import unittest
 import tempfile
 import shutil
 import uuid
-
-import pkg_resources
+import sys
 
 from pynailgun import NailgunException, NailgunConnection
 
@@ -41,7 +40,6 @@ if os.name == 'nt':
         return result
 
 
-@unittest.skip('This test is flaky')
 class TestNailgunConnection(unittest.TestCase):
     def setUp(self):
         self.setUpTransport()
@@ -58,11 +56,7 @@ class TestNailgunConnection(unittest.TestCase):
             self.transport_file = ur'\\.\pipe\{0}'.format(pipe_name)
 
     def getNailgunUberJar(self):
-        stream = pkg_resources.resource_stream(__name__, 'nailgun-uber.jar')
-        uber_jar_path = os.path.join(self.tmpdir, 'nailgun-uber.jar')
-        with open(uber_jar_path, 'wb') as f:
-            f.write(stream.read())
-        return uber_jar_path
+        return 'nailgun-server/target/nailgun-server-0.9.2-SNAPSHOT-uber.jar'
 
     def startNailgun(self):
         if os.name == 'posix':

--- a/pynailgun/test_ng.py
+++ b/pynailgun/test_ng.py
@@ -130,5 +130,7 @@ class TestNailgunConnection(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    for i in range(10):
-        unittest.main(exit=False)
+    for i in range(50):
+        was_successful = unittest.main(exit=False).result.wasSuccessful()
+        if not was_successful:
+            sys.exit(1)

--- a/pynailgun/test_ng.py
+++ b/pynailgun/test_ng.py
@@ -89,6 +89,8 @@ class TestNailgunConnection(unittest.TestCase):
         for i in range(0, 600):
             if not transport_exists(self.transport_file):
                 time.sleep(0.01)
+            else:
+                break
 
         self.assertTrue(transport_exists(self.transport_file))
 
@@ -128,4 +130,5 @@ class TestNailgunConnection(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    for i in range(10):
+        unittest.main(exit=False)

--- a/scripts/travis_run.sh
+++ b/scripts/travis_run.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eux
+
+mvn package
+
+python -m pynailgun.test_ng


### PR DESCRIPTION
`test-ng.py` is an integration test to start nailgun server via local socket on unix and named pipes on windows. 

A small modification: a message "NGServer XXX started" is printed now after the server is ready to accept connections. It allows to connect to the started server from `test-ng.py` reliably.

The appveyor and travis runs can be seen: https://travis-ci.org/ilya-klyuchnikov/nailgun/branches and https://ci.appveyor.com/project/ilya-klyuchnikov/nailgun/history.